### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/integration-examples/nodejs-integration.js
+++ b/integration-examples/nodejs-integration.js
@@ -382,8 +382,15 @@ async function exampleUsage() {
 
 async function createExpressAPI() {
   const express = require('express');
+  const RateLimit = require('express-rate-limit');
   const app = express();
   app.use(express.json());
+
+  // set up rate limiter: maximum 100 requests per 15 minutes per IP
+  const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+  });
 
   const connector = new BlockchainConnector(CONFIG);
   await connector.connect();
@@ -401,8 +408,8 @@ async function createExpressAPI() {
   });
 
   // Verify hash endpoint
-  // TODO: Add rate limiting for production (e.g., express-rate-limit)
-  app.post('/api/verify', async (req, res) => {
+  // Apply rate limiting to the verify endpoint
+  app.post('/api/verify', limiter, async (req, res) => {
     try {
       const { data } = req.body;
       const result = await connector.verifyHash(data);

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   },
   "devDependencies": {
     "json-server": "^0.17.3"
+  },
+  "dependencies": {
+    "express-rate-limit": "^8.2.1"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/RalucaFasie/Trasabilitate-paine/security/code-scanning/4](https://github.com/RalucaFasie/Trasabilitate-paine/security/code-scanning/4)

To fix this issue, add rate limiting middleware to the Express app to prevent abuse of the `/api/verify` endpoint (and ideally other endpoints that perform expensive operations). The most common approach is to use the well-known `express-rate-limit` package, which can be easily configured and imported. Install and import `express-rate-limit`, configure a suitable limiter (e.g., 100 requests per 15 minutes per IP), and apply it as middleware to the `/api/verify` POST route. Optionally, other expensive endpoints like `/api/register` could also be similarly protected.

Code changes needed:
- Add `express-rate-limit` to the list of required packages for the project.
- Insert the import and configuration for the rate limiter near the Express app setup.
- Apply the limiter middleware to the `/api/verify` endpoint (line 405) and, optionally, to `/api/register`. 
  - Since the alert is only for `/api/verify`, you can limit fix to that, but a follow-up recommendation would cover other endpoints.
- These modifications should remain within the shown code, so all changes will be inside the `createExpressAPI` function region of `integration-examples/nodejs-integration.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
