### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/RalucaFasie/Trasabilitate-paine/security/code-scanning/3](https://github.com/RalucaFasie/Trasabilitate-paine/security/code-scanning/3)

To fix the problem, explicitly set the minimum necessary permissions for the `build` job. Since this job only checks out code, installs dependencies, and runs tests (none of which should require write access to repository contents, actions, or packages), the permission can be safely set to `contents: read` (the most restrictive appropriate for most build/test scenarios).

The best fix is to add the following block under the `build` job definition, just before `runs-on`:

```yaml
permissions:
  contents: read
```

This ensures that the `build` job will have the minimal privilege required, adhering to the principle of least privilege. No other code or file changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
